### PR TITLE
Add Maven Scijava version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [![Build Status](https://github.com/mobie/mobie-viewer-fiji/actions/workflows/build.yml/badge.svg)](https://github.com/mobie/mobie-viewer-fiji/actions/workflows/build.yml)
+[![Maven Scijava Version](https://img.shields.io/github/v/tag/mobie/mobie-viewer-fiji?label=Version-[Maven%20Scijava])](https://maven.scijava.org/#browse/browse:releases:org%2Fembl%2Fmobie%2Fmobie-viewer-fiji)
+
 
 [![DOI](https://zenodo.org/badge/177135630.svg)](https://zenodo.org/badge/latestdoi/177135630)
 


### PR DESCRIPTION
Hi @tischi, 

I find these badges pretty convenient when you look for the current version. Here's one example if you wish. I usually make them with a llm, giving an example, the github address and the group and artifact (provided the repo is published in maven scijava)

Cheers!